### PR TITLE
Add periodicity to the objective

### DIFF
--- a/src/AudzeEglaisObjective.jl
+++ b/src/AudzeEglaisObjective.jl
@@ -1,16 +1,17 @@
 @inline function _AudzeEglaisDist(LHC)
-    n,d = size(LHC) 
+    n,d = size(LHC)
     dist = 0.0
-    dist_tmp = 0.0
 
     # Squared l-2 norm of distances between all (unique) points
     for i = 2:n
         for j = 1:i-1
+            dist_tmp = 0.0
             for k = 1:d
-                @inbounds dist_tmp += (LHC[i,k]-LHC[j,k])^2
+                @inbounds dist_comp = LHC[i,k]-LHC[j,k]
+                dist_comp -= round(dist/n) * n
+                dist_tmp += dist_comp^2
             end
             @inbounds dist += 1/dist_tmp
-            dist_tmp = 0.0
         end
     end
     output = 1/dist
@@ -18,13 +19,13 @@
 end
 
 function _AudzeEglaisObjective(dim::Continuous,LHC)
-    output = _AudzeEglaisDist(LHC)    
+    output = _AudzeEglaisDist(LHC)
     return output
 end
 
 function _AudzeEglaisObjective(dim::Categorical,LHC)
-    output = _AudzeEglaisDist(LHC)     
-    output == Inf ? 0 : output    
+    output = _AudzeEglaisDist(LHC)
+    output == Inf ? 0 : output
 end
 
 """
@@ -36,7 +37,7 @@ Audze-Eglais distance which normally is minimized.
 function AudzeEglaisObjective(LHC::T; dims::Array{V,1} =[Continuous() for i in 1:size(LHC,2)],
                                             interSampleWeight::Float64=1.0,
                                             ) where T <: AbstractArray where V <: LHCDimension
-    
+
     out = 0.0
 
     #Compute the objective function among all points
@@ -46,7 +47,7 @@ function AudzeEglaisObjective(LHC::T; dims::Array{V,1} =[Continuous() for i in 1
     categoricalDimInds = findall(x->typeof(x)==Categorical,dims)
     for i in categoricalDimInds
         for j = 1:dims[i].levels
-            subLHC = @view LHC[LHC[:,i] .== j,:] 
+            subLHC = @view LHC[LHC[:,i] .== j,:]
             out += _AudzeEglaisObjective(dims[i],subLHC)*dims[i].weight
         end
     end

--- a/src/AudzeEglaisObjective.jl
+++ b/src/AudzeEglaisObjective.jl
@@ -7,11 +7,11 @@
         for j = 1:i-1
             dist_tmp = 0.0
             for k = 1:d
-                @inbounds dist_comp = LHC[i,k]-LHC[j,k]
-                dist_comp -= round(dist_comp/n) * n
+                @inbounds dist_comp = abs(LHC[i,k]-LHC[j,k])
+                dist_comp = min(dist_comp,n-dist_comp)
                 dist_tmp += dist_comp^2
             end
-            @inbounds dist += 1/dist_tmp
+            dist += 1/dist_tmp
         end
     end
     output = 1/dist

--- a/src/AudzeEglaisObjective.jl
+++ b/src/AudzeEglaisObjective.jl
@@ -8,7 +8,7 @@
             dist_tmp = 0.0
             for k = 1:d
                 @inbounds dist_comp = LHC[i,k]-LHC[j,k]
-                dist_comp -= round(dist/n) * n
+                dist_comp -= round(dist_comp/n) * n
                 dist_tmp += dist_comp^2
             end
             @inbounds dist += 1/dist_tmp


### PR DESCRIPTION
First of all thanks a lot for the package.

I have used it to optimize a design of 2k points in 7D and afterwards optimize a selection of 200 points. However, I found that the interior of the subset looks emptier than the skin of the hypercube.

This didn't show up in a 2D toy example I did earlier. So I doubt this has to do with the fact that the skin to interior volume ratio grows rapidly with the number of dimensions.

A straightforward fix is to make the hypercube periodic, and always use the closest pair
among all images when doing the pair summation.

Below is the plan and fitness of the plan with 2k points:
![plan](https://user-images.githubusercontent.com/7311098/76173455-1edc2300-6176-11ea-9eb7-8e818668bc07.png)
![fit](https://user-images.githubusercontent.com/7311098/76173456-1edc2300-6176-11ea-998d-57c6479e0aca.png)


And the subset:
![subplan](https://user-images.githubusercontent.com/7311098/76173461-24396d80-6176-11ea-964e-2286865439fc.png)
![subfit](https://user-images.githubusercontent.com/7311098/76173462-24d20400-6176-11ea-8072-d074ac87610c.png)
