### PR TITLE
Add multithreading to LHCoptim

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ julia:
   - 1.0
   - 1.5
   - nightly
+env:
+  - JULIA_NUM_THREADS=2
 branches:
   only:
     - master

--- a/docs/src/man/lhcoptim.md
+++ b/docs/src/man/lhcoptim.md
@@ -29,7 +29,8 @@ LHCoptim(n::Int,d::Int,gens;    rng::U=Random.GLOBAL_RNG,
                                 dims::Array{T,1}=[Continuous() for i in 1:d],
                                 interSampleWeight::Float64=1.0,
                                 periodic_ae::Bool=false,
-                                ae_power::Union{Int,Float64}=2) where T <: LHCDimension where U <: AbstractRNG
+                                ae_power::Union{Int,Float64}=2,
+                                threading=false) where T <: LHCDimension where U <: AbstractRNG
 ```
 Where `gens` is the number of generations to run the optimisation for. The population
 size, number of samples selected for tournament, as well as the probability for tournament
@@ -38,6 +39,8 @@ selection in the genetic algorithm, can be accessed with the optional arguments
 optimal depending on the number of dimensions and the size of the plan.
 
 The RNG can be specified or else the global RNG will be used. 
+
+Multithreading can be used by starting Julia with multiple threads and specifying `threads=true`.
 
 The optimisation of a sampling plan is started from a random plan which is also
 an exported function.

--- a/src/GA.jl
+++ b/src/GA.jl
@@ -51,9 +51,9 @@ function _fixedcross!(rng,offspr,parone,partwo,randlock)
 
     #generate a random location in the gene
     n = length(parone)
-    lock(randlock)
-        loc = sample(rng,1:n-1)
-    unlock(randlock)
+    loc = lock(randlock) do
+        sample(rng,1:n-1)
+    end
     offspr[1:loc] = parone[1:loc]
     i = loc+1
     while i < n+1

--- a/src/GA.jl
+++ b/src/GA.jl
@@ -45,13 +45,15 @@ end
     function _fixedcross!(rng,offspr,parone,partwo)
 Fixed point crossover of two parents to create one offspring.
 """
-function _fixedcross!(rng,offspr,parone,partwo)
+function _fixedcross!(rng,offspr,parone,partwo,randlock)
 
     offspr .= 0
 
     #generate a random location in the gene
     n = length(parone)
-    loc = sample(rng,1:n-1)
+    lock(randlock)
+        loc = sample(rng,1:n-1)
+    unlock(randlock)
     offspr[1:loc] = parone[1:loc]
     i = loc+1
     while i < n+1
@@ -72,10 +74,10 @@ end
     function fixedcross!(rng,offsprone,offsprtwo,parone,partwo)
 Fixed point crossover of two parents to create two offspring.
 """
-function fixedcross!(rng,offsprone,offsprtwo,parone,partwo)
+function fixedcross!(rng,offsprone,offsprtwo,parone,partwo,randlock=ReentrantLock())
 
-    _fixedcross!(rng,offsprone,parone,partwo)
-    _fixedcross!(rng,offsprtwo,partwo,parone)
+    _fixedcross!(rng,offsprone,parone,partwo,randlock)
+    _fixedcross!(rng,offsprtwo,partwo,parone,randlock)
 
     return offsprone, offsprtwo
 

--- a/src/LatinHypercubeSampling.jl
+++ b/src/LatinHypercubeSampling.jl
@@ -15,8 +15,6 @@ export  randomLHC,
 using StatsBase
 using Random
 import Random.randperm
-using Base.Threads
-import Base.Threads.threading_run
 
 abstract type LHCDimension end
 
@@ -34,15 +32,14 @@ include("GA.jl")
 include("AudzeEglaisObjective.jl")
 
 #make an @threads-equivalent that is a no-op if threading is not requested
-#nesting @threads not possible due to https://github.com/JuliaLang/julia/issues/37691
 macro maybe_threaded(flag, ex)
-    quote
-        if !$(esc(flag))
-            $(esc(ex))
+    esc(quote
+        if !$flag
+            $ex
         else
-            $(Threads._threadsfor(ex.args[1], ex.args[2], :default))
+            Threads.@threads $ex
         end
-    end
+    end)
 end
 
 function randperm(rng,dim::Continuous,n)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -53,15 +53,16 @@ end
     partwo = [4,2,5,1,6,8,3,7]
     offsprone = similar(parone)
     offsprtwo = similar(parone)
+    randlock = ReentrantLock()
     rng = StableRNGs.StableRNG(1)
-    @test [1,2,3,4,5,6,8,7] == LatinHypercubeSampling._fixedcross!(rng,offsprone,parone,partwo)
+    @test [1,2,3,4,5,6,8,7] == LatinHypercubeSampling._fixedcross!(rng,offsprone,parone,partwo,randlock)
     rng = StableRNGs.StableRNG(1)
-    @test [4,2,5,1,3,6,7,8]== LatinHypercubeSampling._fixedcross!(rng,offsprone,partwo,parone)
+    @test [4,2,5,1,3,6,7,8]== LatinHypercubeSampling._fixedcross!(rng,offsprone,partwo,parone,randlock)
 
     rng = StableRNGs.StableRNG(1)
-    @test [1,2,3,4,5,6,8,7] == LatinHypercubeSampling.fixedcross!(rng,offsprone,offsprtwo,parone,partwo)[1]
+    @test [1,2,3,4,5,6,8,7] == LatinHypercubeSampling.fixedcross!(rng,offsprone,offsprtwo,parone,partwo,randlock)[1]
     rng = StableRNGs.StableRNG(1)
-    @test [4,2,5,1,3,6,7,8] == LatinHypercubeSampling.fixedcross!(rng,offsprone,offsprtwo,parone,partwo)[2]
+    @test [4,2,5,1,3,6,7,8] == LatinHypercubeSampling.fixedcross!(rng,offsprone,offsprtwo,parone,partwo,randlock)[2]
 end
 
 @testset "inversion" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -75,18 +75,18 @@ end
 
 end
 
-@testset "is optimization result still an LHC" begin
+@testset "is optimization result still an LHC" for threading in (true, false)
     numPoints = 64
     numDims = 10
     numGens = 100
 
-    X = LHCoptim(numPoints,numDims,numGens;popsize=20,ntour=2,ptour=0.8,periodic_ae=false)[1]
+    X = LHCoptim(numPoints,numDims,numGens;popsize=20,ntour=2,ptour=0.8,periodic_ae=false,threading=threading)[1]
     n, d = size(X)
     for i = 1:d
         @test length(unique(X[:,i])) == n
     end
 
-    X = LHCoptim(numPoints,numDims,numGens;popsize=20,ntour=2,ptour=0.8,periodic_ae=true)[1]
+    X = LHCoptim(numPoints,numDims,numGens;popsize=20,ntour=2,ptour=0.8,periodic_ae=true,threading=threading)[1]
     n, d = size(X)
     for i = 1:d
         @test length(unique(X[:,i])) == n
@@ -106,18 +106,18 @@ end
 
 end
 
-@testset "is the fittest individual kept" begin
+@testset "is the fittest individual kept" for threading in (true,false)
     numPoints = 64
     numDims = 10
     numGens = 100
 
-    X,fitnesses = LHCoptim(numPoints,numDims,numGens;popsize=20,ntour=2,ptour=0.8)
+    X,fitnesses = LHCoptim(numPoints,numDims,numGens;popsize=20,ntour=2,ptour=0.8,threading=threading)
     @test sort(fitnesses) == fitnesses
     fitnesses = subLHCoptim(X,numPoints÷2,numGens;popsize=20,ntour=2,ptour=0.8)[2]
     @test sort(fitnesses) == fitnesses
 end
 
-@testset "categorical LHC" begin
+@testset "categorical LHC" for threading in (true, false)
     numPoints = 64
     numCat = 4
     W = 1.0
@@ -126,7 +126,7 @@ end
     
     numGens = 100
 
-    X = LHCoptim!(randomLHC(numPoints,dims),numGens;dims=dims,interSampleWeight=W)[1]
+    X = LHCoptim!(randomLHC(numPoints,dims),numGens;dims=dims,interSampleWeight=W,threading=threading)[1]
 
     n, d = size(X)
     for (i, dim) in enumerate(dims)


### PR DESCRIPTION
Hej!

I had a stab at adding multithreading to `LHCoptim`. Profiling showed that most of the time was spent in `_AudzeEglaisDist` followed by `_fixedcross!`, so these are the two portions of `LHCoptim` that are threaded.

It's worth to note that one global RNG is still used (instead of each thread having its own), but this doesn't ensure consistent results between different number of threads, nor repeatable results on a number of threads > 1.

To make threading opt-in even if multiple threads are available, there is a macro called `@maybe_threaded` ~~which unfortunately uses a non-exported function from `Base.Threads`, but this was the only way I could make it work since `Threads.@threads` doesn't compose well within another macro.~~

Performance wise, I have only been able to test on my 8 year old laptop with two glorious cores, but the results look quite promising:
```
julia> @benchmark LHCoptim(100,3,1000, threading = false)
BenchmarkTools.Trial: 
  memory estimate:  578.03 MiB
  allocs estimate:  1242768
  --------------
  minimum time:     3.639 s (0.83% GC)
  median time:      3.672 s (0.83% GC)
  mean time:        3.672 s (0.83% GC)
  maximum time:     3.705 s (0.84% GC)
  --------------
  samples:          2
  evals/sample:     1

julia> @benchmark LHCoptim(100,3,1000, threading = true)
BenchmarkTools.Trial: 
  memory estimate:  566.63 MiB
  allocs estimate:  727455
  --------------
  minimum time:     2.121 s (1.28% GC)
  median time:      2.128 s (1.31% GC)
  mean time:        2.133 s (1.33% GC)
  maximum time:     2.148 s (1.30% GC)
  --------------
  samples:          3
  evals/sample:     1
```

It might be a good idea to benchmark on a beefier machine too before merging :)

/Emil